### PR TITLE
Allow all users file permissions

### DIFF
--- a/L1C_Aux/write_functions.py
+++ b/L1C_Aux/write_functions.py
@@ -16,7 +16,8 @@ def get_output_filename(args,fiduceo_fn):
         +'/'+fiduceo_fn[36:38]+'/'
 
     if not os.path.isdir(outdir):
-        os.makedirs(outdir)
+        os.makedirs(outdir,0777)
+
 
     out = outdir+outfile
 


### PR DESCRIPTION
Allow permission for all FIDUCEO group_workspace users to create, read and write in folders made by the function get_output_filename