### PR TITLE
New file creation issue fixes

### DIFF
--- a/L1C_Aux/collocate_hirs_avhrr.py
+++ b/L1C_Aux/collocate_hirs_avhrr.py
@@ -37,6 +37,13 @@ def create_filepaths(args):
 
     return hirs_dir,fiduceo_dir,gac_dir,l1c_dir
 
+def closest(num,arr):
+    curr = arr[0]
+    for val in arr:
+        if abs (num - val) < abs (num - curr):
+            curr = val
+    return curr
+
 if __name__ in '__main__':
 
     #Pass in the date to process
@@ -58,143 +65,180 @@ if __name__ in '__main__':
     string_date_hirs = in_date[0:4]+'/'+in_date[4:6]+'/'+in_date[6:8]+'/'
     
     for f in os.listdir(hirs_dir+string_date_hirs):
+        try:
+            fiduceo_filename = rf.construct_fiduceo(fiduceo_dir,string_date_hirs,f)
 
-        fiduceo_filename = rf.construct_fiduceo(fiduceo_dir,string_date_hirs,f)
-        time_hirs = rf.read_time(hirs_dir+string_date_hirs+f)
-        
-        plt.figure()
-        plt.xlabel('Lon')
-        plt.ylabel('Lat')
+            time_hirs = rf.read_time(hirs_dir+string_date_hirs+f)
 
-        fileobj = -1
+            plt.figure()
+            plt.xlabel('Lon')
+            plt.ylabel('Lat')
 
-        for date in [prev,in_date,next]:
-            string_date = date[0:4]+'/'+date[4:6]+'/'+date[6:8]+'/'
+            fileobj = -1
 
-
-            
-            for g in os.listdir(gac_dir+string_date):
-                time_gac = rf.read_time(gac_dir+string_date+g)               
-                #Identify files where the HIRS/AVHRR times overlap
-                if np.min(time_gac) > np.max(time_hirs):
-                    continue
-                elif np.max(time_gac) < np.min(time_hirs):
-                    continue
-                else:
-                    print 'overlap'
-                    #Identify overlap times for GAC and HIRS
-                    gac_min,gac_max,hirs_min,hirs_max,data_check \
-                        = td.time_mask(time_hirs,time_gac)
-                    if data_check == True:
-                    #Read in for GAC and HIRS: lat,lon and l2 flags
-                        gac_lat,gac_lon,gac_flags \
-                        = rf.refine_geo(gac_dir+string_date+g,gac_min,gac_max)
-                        hirs_lat,hirs_lon,hirs_flags \
-                        = rf.refine_geo(hirs_dir+string_date_hirs+f,\
-                                         hirs_min,hirs_max)
-
-                    #Read in GAC and HIRS BT
-                        hirs_bt,hirs_noise,hirs_obs,hirs_ind,hirs_str,hirs_com\
-                        = rf.read_hirs_obs(fiduceo_dir+string_date_hirs \
-                                               +fiduceo_filename,hirs_min,hirs_max)
-                        l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
-                        print l1c_filename
-                        gac_bt,avhrr_obs,avhrr_noise \
-                        = rf.read_avhrr_obs(l1c_dir+string_date+l1c_filename,\
-                                                gac_min,gac_max,args.hirs_sensor)
-
-                        if os.path.isfile(avhrr_sim_dir+string_date+g):
-                            gac_dy = rf.read_dy(avhrr_sim_dir+string_date+g,gac_min,\
-                                                gac_max)
-                        else:
-                            gac_dy=np.zeros([1])
-
-                    #Read in the PClear arrays
-                        gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
-            
-                        hirs_prob = rf.read_pclear(hirs_dir+string_date_hirs+f,hirs_min,\
-                                                hirs_max)
-
-                    #### Extra probabilities from different runs - move from
-                    #### core code??
-#                    hirs_prob_lim = rf.read_pclear(comp_dir+string_date_hirs+f,hirs_min,\
-#                                                hirs_max)
-#                    hirs_prob_five =  rf.read_pclear(all_dir+string_date_hirs+f,hirs_min,\
-#                                                hirs_max)
-
-                    #Read in the dY arrays
-                        dy = rf.read_ffm(hirs_dir+string_date_hirs+f,hirs_min,hirs_max)
-
-                    #Co-locate the GAC and HIRS arrays
-                        lat_centre,lon_centre,flag_centre,gac_as_hirs_min,\
-                        gac_as_hirs_mean,gac_bt_mean,gac_bt_cloud_std,gac_bt_all_std,\
-                        cloud_frac,gac_as_hirs_dy,gac_as_hirs_n,gac_as_hirs_noise, \
-                        gac_as_hirs_landmask \
-                        = col.collocate_gac_hirs(time_gac,time_hirs,gac_min,gac_max,\
-                                                     hirs_min,hirs_max,gac_lat,gac_lon,\
-                                                     gac_flags,hirs_flags,gac_prob,\
-                                                     avhrr_obs,avhrr_noise,args.hirs_sensor,gac_dy)
+            for date in [prev,in_date,next]:
+                string_date = date[0:4]+'/'+date[4:6]+'/'+date[6:8]+'/'
 
 
-                    #Calculate the cloud height
-  #                  try:
-  #                      cloud_height = np.zeros([lat_centre.shape[0],lat_centre.shape[1]])
-  #                      mask = (dy[7,:,:] <= 0.)
-  #                      cloud_height[mask] = abs(dy[7,:,:][mask])*(1./6.)
-  #                      try:
-  #                          cloud_height[dy[7,:,:].mask] = -np.nan
-  #                      except:
-  #                          pass
-  #                  except:
-  #                      pass
 
-                    #Write out data
-                        outfile = wf.get_output_filename(args,fiduceo_filename)
+                for g in os.listdir(gac_dir+string_date):
+                    time_gac = rf.read_time(gac_dir+string_date+g)               
+                    #Identify files where the HIRS/AVHRR times overlap
+                    if np.min(time_gac) > np.max(time_hirs):
+                        continue
+                    elif np.max(time_gac) < np.min(time_hirs):
+                        continue
+                    else:
+                        print 'overlap'
+                        #Identify overlap times for GAC and HIRS
+                        gac_min,gac_max,hirs_min,hirs_max,data_check \
+                            = td.time_mask(time_hirs,time_gac)
+                        if data_check == True:
+                        #Read in for GAC and HIRS: lat,lon and l2 flags
 
-                        if fileobj == -1:
-                            fileobj,var_rtm,var_lat,var_lon,var_flag,\
-                                var_hlat,var_hlon,var_hflag,var_a_obs,var_a_noise, \
-                                var_cloud_frac,var_cloud_height,var_cloud_std,\
-                                var_obs_std,var_n,var_likelihood,var_rtm_land, \
-                                var_likelihood_land,var_landmask \
-                                = wf.create_output(hirs_obs,avhrr_obs,\
-                                                   time_hirs,outfile)
+                            gac_lat,gac_lon,gac_flags \
+                            = rf.refine_geo(gac_dir+string_date+g,gac_min,gac_max)
+                            hirs_lat,hirs_lon,hirs_flags \
+                            = rf.refine_geo(hirs_dir+string_date_hirs+f,\
+                                             hirs_min,hirs_max)
 
- 
-                        fileobj = wf.write_data(hirs_obs,dy,lat_centre,lon_centre,\
-                                                flag_centre,hirs_lat,hirs_lon,\
-                                                hirs_flags,gac_bt_mean,gac_as_hirs_noise,\
-                                                fileobj,hirs_min,hirs_max,cloud_frac,\
-                                                gac_bt_cloud_std,\
-                                                gac_bt_all_std,gac_as_hirs_n,hirs_prob,\
-                                                gac_as_hirs_landmask,var_rtm,var_lat,var_lon,\
-                                                var_flag,var_hlat,var_hlon,\
-                                                var_hflag,var_a_obs,var_a_noise,\
-                                                var_cloud_frac,var_cloud_height,\
-                                                var_cloud_std,var_obs_std,var_n,var_likelihood,\
-                                                var_rtm_land,var_likelihood_land,var_landmask)
-                    
+                        #Read in GAC and HIRS BT
+                            hirs_bt,hirs_noise,hirs_obs,hirs_ind,hirs_str,hirs_com\
+                            = rf.read_hirs_obs(fiduceo_dir+string_date_hirs \
+                                                   +fiduceo_filename,hirs_min,hirs_max)
+                            #l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
+                            #print "l1c_dir = ",l1c_dir
+                            #print "g = ",g
+                            #print "string_date = ",string_date
+                            #print "gac_dir = ", gac_dir
+                            l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
+                            try:
+                                os.path.isfile(l1c_dir+string_date+l1c_filename)
+                                #l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
+                                gac_bt,avhrr_obs,avhrr_noise \
+                                = rf.read_avhrr_obs(l1c_dir+string_date+l1c_filename,\
+                                                    gac_min,gac_max,args.hirs_sensor)
+                                if os.path.isfile(avhrr_sim_dir+string_date+g):
+                                    gac_dy = rf.read_dy(avhrr_sim_dir+string_date+g,gac_min,\
+                                                    gac_max)
+                                else:
+                                    gac_dy=np.zeros([1])
+                                gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)                            
+                            except:
+                                print "Mismatched file found in l2p and l1c for: ",g
+                                old_g_time = int(g[8:14])
+                                new_g_list = os.listdir(l1c_dir+string_date)
+                                newlist = np.array([int(x[8:14]) for x in new_g_list])
+                                new_g_time = closest(old_g_time,newlist)
+                                new_g = str(g[:8])+str(new_g_time)+str(g[14:])
+                                new_l1c_filename = str(l1c_filename[:8])+str(new_g_time)+str(l1c_filename[14:])
+                                #print "New g made: ",new_g
+                                #print "Old l1c_filename: ",l1c_filename
+                                #l1c_filename = rf.construct_l1c(l1c_dir,string_date,new_g,gac_dir)
+                                print "New l1c_filename: ",new_l1c_filename
+                                gac_bt,avhrr_obs,avhrr_noise \
+                                = rf.read_avhrr_obs(l1c_dir+string_date+new_l1c_filename,\
+                                                    gac_min,gac_max,args.hirs_sensor)
+                                if os.path.isfile(avhrr_sim_dir+string_date+g):
+                                    gac_dy = rf.read_dy(avhrr_sim_dir+string_date+g,gac_min,\
+                                                    gac_max)
+                                else:
+                                    gac_dy=np.zeros([1])
+                                gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
+                            #if os.path.isfile(avhrr_sim_dir+string_date+g):
+                                #gac_dy = rf.read_dy(avhrr_sim_dir+string_date+g,gac_min,\
+                                                    #gac_max)
+                            #else:
+                                #gac_dy=np.zeros([1])
 
-                    #Make some comparison plots
+                        #Read in the PClear arrays
+                            #gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
 
-                        mask_gac,mask_hirs \
-                        = pr.plot_geoloc(lat_centre,lon_centre,flag_centre,hirs_lat,\
-                                          hirs_lon,hirs_flags)
-#                    pr.plot_cloud_char(cloud_frac,gac_bt_std,gac_bt_mean,ch8)
+                            hirs_prob = rf.read_pclear(hirs_dir+string_date_hirs+f,hirs_min,\
+                                                    hirs_max)
+
+                        #### Extra probabilities from different runs - move from
+                        #### core code??
+    #                    hirs_prob_lim = rf.read_pclear(comp_dir+string_date_hirs+f,hirs_min,\
+    #                                                hirs_max)
+    #                    hirs_prob_five =  rf.read_pclear(all_dir+string_date_hirs+f,hirs_min,\
+    #                                                hirs_max)
+
+                        #Read in the dY arrays
+                            dy = rf.read_ffm(hirs_dir+string_date_hirs+f,hirs_min,hirs_max)
+
+                        #Co-locate the GAC and HIRS arrays
+                            lat_centre,lon_centre,flag_centre,gac_as_hirs_min,\
+                            gac_as_hirs_mean,gac_bt_mean,gac_bt_cloud_std,gac_bt_all_std,\
+                            cloud_frac,gac_as_hirs_dy,gac_as_hirs_n,gac_as_hirs_noise, \
+                            gac_as_hirs_landmask \
+                            = col.collocate_gac_hirs(time_gac,time_hirs,gac_min,gac_max,\
+                                                         hirs_min,hirs_max,gac_lat,gac_lon,\
+                                                         gac_flags,hirs_flags,gac_prob,\
+                                                         avhrr_obs,avhrr_noise,args.hirs_sensor,gac_dy)
 
 
-#                    pr.plot_sim_comp(gac_bt_mean,gac_as_hirs_dy,hirs_bt,ch8)
-#                    cm.explore_bias(hirs_bt,gac_bt_mean,hirs_noise,gac_bt_all_std,\
-#                                        gac_as_hirs_n)
+                        #Calculate the cloud height
+      #                  try:
+      #                      cloud_height = np.zeros([lat_centre.shape[0],lat_centre.shape[1]])
+      #                      mask = (dy[7,:,:] <= 0.)
+      #                      cloud_height[mask] = abs(dy[7,:,:][mask])*(1./6.)
+      #                      try:
+      #                          cloud_height[dy[7,:,:].mask] = -np.nan
+      #                      except:
+      #                          pass
+      #                  except:
+      #                      pass
 
-  #                  cm.calc_stats(hirs_bt,hirs_noise,gac_bt_mean,gac_as_hirs_mean,\
-  #                                    hirs_prob,gac_bt_std,cloud_frac,gac_bt_mean_ext,\
-  #                                    gac_as_hirs_mean_ext,gac_bt_std_ext,cloud_frac_ext)
+                        #Write out data
+                            outfile = wf.get_output_filename(args,fiduceo_filename)
 
-  #                  pr.plot_cloudmasks(gac_as_hirs_min,hirs_prob,mask_gac,mask_hirs,\
-  #                                      ch7,ch8,ch10,ch11,ch12,hirs_prob_lim,\
-  #                                      hirs_prob_five,gac_as_hirs_mean,cloud_frac)
+                            if fileobj == -1:
+                                fileobj,var_rtm,var_lat,var_lon,var_flag,\
+                                    var_hlat,var_hlon,var_hflag,var_a_obs,var_a_noise, \
+                                    var_cloud_frac,var_cloud_height,var_cloud_std,\
+                                    var_obs_std,var_n,var_likelihood,var_rtm_land, \
+                                    var_likelihood_land,var_landmask \
+                                    = wf.create_output(hirs_obs,avhrr_obs,\
+                                                       time_hirs,outfile)
 
-                    
-        #Close output file
-        fileobj.close()
+
+                            fileobj = wf.write_data(hirs_obs,dy,lat_centre,lon_centre,\
+                                                    flag_centre,hirs_lat,hirs_lon,\
+                                                    hirs_flags,gac_bt_mean,gac_as_hirs_noise,\
+                                                    fileobj,hirs_min,hirs_max,cloud_frac,\
+                                                    gac_bt_cloud_std,\
+                                                    gac_bt_all_std,gac_as_hirs_n,hirs_prob,\
+                                                    gac_as_hirs_landmask,var_rtm,var_lat,var_lon,\
+                                                    var_flag,var_hlat,var_hlon,\
+                                                    var_hflag,var_a_obs,var_a_noise,\
+                                                    var_cloud_frac,var_cloud_height,\
+                                                    var_cloud_std,var_obs_std,var_n,var_likelihood,\
+                                                    var_rtm_land,var_likelihood_land,var_landmask)
+
+
+                        #Make some comparison plots
+
+                            mask_gac,mask_hirs \
+                            = pr.plot_geoloc(lat_centre,lon_centre,flag_centre,hirs_lat,\
+                                              hirs_lon,hirs_flags)
+    #                    pr.plot_cloud_char(cloud_frac,gac_bt_std,gac_bt_mean,ch8)
+
+
+    #                    pr.plot_sim_comp(gac_bt_mean,gac_as_hirs_dy,hirs_bt,ch8)
+    #                    cm.explore_bias(hirs_bt,gac_bt_mean,hirs_noise,gac_bt_all_std,\
+    #                                        gac_as_hirs_n)
+
+      #                  cm.calc_stats(hirs_bt,hirs_noise,gac_bt_mean,gac_as_hirs_mean,\
+      #                                    hirs_prob,gac_bt_std,cloud_frac,gac_bt_mean_ext,\
+      #                                    gac_as_hirs_mean_ext,gac_bt_std_ext,cloud_frac_ext)
+
+      #                  pr.plot_cloudmasks(gac_as_hirs_min,hirs_prob,mask_gac,mask_hirs,\
+      #                                      ch7,ch8,ch10,ch11,ch12,hirs_prob_lim,\
+      #                                      hirs_prob_five,gac_as_hirs_mean,cloud_frac)
+
+
+            #Close output file
+            fileobj.close()
+        except:
+            print "Fiduceo file match failed - ",f

--- a/L1C_Aux/collocate_hirs_avhrr.py
+++ b/L1C_Aux/collocate_hirs_avhrr.py
@@ -106,12 +106,10 @@ if __name__ in '__main__':
                             hirs_bt,hirs_noise,hirs_obs,hirs_ind,hirs_str,hirs_com\
                             = rf.read_hirs_obs(fiduceo_dir+string_date_hirs \
                                                    +fiduceo_filename,hirs_min,hirs_max)
-                            #l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
-                            #print "l1c_dir = ",l1c_dir
-                            #print "g = ",g
-                            #print "string_date = ",string_date
-                            #print "gac_dir = ", gac_dir
+
                             l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
+                            
+                            # Code now attempts to find file with matching hour start time
                             try:
                                 os.path.isfile(l1c_dir+string_date+l1c_filename)
                                 #l1c_filename = rf.construct_l1c(l1c_dir,string_date,g,gac_dir)
@@ -123,7 +121,10 @@ if __name__ in '__main__':
                                                     gac_max)
                                 else:
                                     gac_dy=np.zeros([1])
-                                gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)                            
+                                gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
+                                
+                            # If hour-matched start time is missed, it now finds the closest in time and replaces 
+                            # l1c_filename with the a new version which contains the time of the nearest file
                             except:
                                 print "Mismatched file found in l2p and l1c for: ",g
                                 old_g_time = int(g[8:14])
@@ -132,9 +133,6 @@ if __name__ in '__main__':
                                 new_g_time = closest(old_g_time,newlist)
                                 new_g = str(g[:8])+str(new_g_time)+str(g[14:])
                                 new_l1c_filename = str(l1c_filename[:8])+str(new_g_time)+str(l1c_filename[14:])
-                                #print "New g made: ",new_g
-                                #print "Old l1c_filename: ",l1c_filename
-                                #l1c_filename = rf.construct_l1c(l1c_dir,string_date,new_g,gac_dir)
                                 print "New l1c_filename: ",new_l1c_filename
                                 gac_bt,avhrr_obs,avhrr_noise \
                                 = rf.read_avhrr_obs(l1c_dir+string_date+new_l1c_filename,\
@@ -145,14 +143,7 @@ if __name__ in '__main__':
                                 else:
                                     gac_dy=np.zeros([1])
                                 gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
-                            #if os.path.isfile(avhrr_sim_dir+string_date+g):
-                                #gac_dy = rf.read_dy(avhrr_sim_dir+string_date+g,gac_min,\
-                                                    #gac_max)
-                            #else:
-                                #gac_dy=np.zeros([1])
 
-                        #Read in the PClear arrays
-                            #gac_prob = rf.read_pclear(gac_dir+string_date+g,gac_min,gac_max)
 
                             hirs_prob = rf.read_pclear(hirs_dir+string_date_hirs+f,hirs_min,\
                                                     hirs_max)

--- a/L1C_Aux/read_functions.py
+++ b/L1C_Aux/read_functions.py
@@ -167,11 +167,12 @@ def construct_fiduceo(fiduceo_dir,string_date_hirs,infile):
         instrument = instrument[:-1]
     acq_time = infile[0:10]
 
-    print instrument,acq_time
-    print fiduceo_dir+string_date_hirs
+    #print instrument,acq_time
+    #print fiduceo_dir+string_date_hirs
 
     pattern = 'FIDUCEO_FCDR_L1C_HIRS*_'+instrument+'_'+acq_time+'*.nc'
-    print pattern
+    #print pattern
+    #print 'list of files: ',os.listdir(fiduceo_dir+string_date_hirs)
     filename = fnmatch.filter(os.listdir(fiduceo_dir+string_date_hirs),pattern)[0]
 
     return filename

--- a/L1C_Aux/read_functions.py
+++ b/L1C_Aux/read_functions.py
@@ -166,8 +166,12 @@ def construct_fiduceo(fiduceo_dir,string_date_hirs,infile):
     else:
         instrument = instrument[:-1]
     acq_time = infile[0:10]
-
+    
+    print instrument,acq_time	
+    print fiduceo_dir+string_date_hirs
+    
     pattern = 'FIDUCEO_FCDR_L1C_HIRS*_'+instrument+'_'+acq_time+'*.nc'
+    print pattern
     filename = fnmatch.filter(os.listdir(fiduceo_dir+string_date_hirs),pattern)[0]
 
     return filename

--- a/L1C_Aux/read_functions.py
+++ b/L1C_Aux/read_functions.py
@@ -166,10 +166,10 @@ def construct_fiduceo(fiduceo_dir,string_date_hirs,infile):
     else:
         instrument = instrument[:-1]
     acq_time = infile[0:10]
-    
-    print instrument,acq_time	
+
+    print instrument,acq_time
     print fiduceo_dir+string_date_hirs
-    
+
     pattern = 'FIDUCEO_FCDR_L1C_HIRS*_'+instrument+'_'+acq_time+'*.nc'
     print pattern
     filename = fnmatch.filter(os.listdir(fiduceo_dir+string_date_hirs),pattern)[0]

--- a/L1C_Aux/read_functions.py
+++ b/L1C_Aux/read_functions.py
@@ -167,12 +167,7 @@ def construct_fiduceo(fiduceo_dir,string_date_hirs,infile):
         instrument = instrument[:-1]
     acq_time = infile[0:10]
 
-    #print instrument,acq_time
-    #print fiduceo_dir+string_date_hirs
-
     pattern = 'FIDUCEO_FCDR_L1C_HIRS*_'+instrument+'_'+acq_time+'*.nc'
-    #print pattern
-    #print 'list of files: ',os.listdir(fiduceo_dir+string_date_hirs)
     filename = fnmatch.filter(os.listdir(fiduceo_dir+string_date_hirs),pattern)[0]
 
     return filename


### PR DESCRIPTION
This pull fixes two issues with the file name timing of l1c and l2p files. 

1) create_fiduceo path is tried before failing using the hour of the start time on the file. This prevents later files not being created in the day due to the job exiting early at a mis-timed file. It will instead simply be skipped.

2) For filenames with times that match the hour, but not minute or seconds, a new function determines the closest matching time file, which should be the same file but offset by a few seconds., and uses this filename instead. This does not currently ensure the files are matched within a time (new fix needed for that, coming soon) but prevents failure of the file and early exit of the job when filenames don't match exactly. Instances of mismatched files and complete mismatch failures are recorded in the log file. 

Further work is needed on restricting the closest file by time, and to extend for scenarios where differences in time lead to different hours or even days. 

